### PR TITLE
Remove bops, browserify's Buffer now works better!

### DIFF
--- a/examples/basic_browser.js
+++ b/examples/basic_browser.js
@@ -1,6 +1,0 @@
-var compact2string = require("../");
-var bops = require("bops");
-
-var iphost = compact2string(bops.from("0A0A0A05FF80", "hex"));
-
-console.log(iphost);

--- a/index.js
+++ b/index.js
@@ -1,11 +1,9 @@
-var bops = require('bops');
-
 module.exports = compact2string = function (buf) {
 
   if(buf.length !== 6)
     throw new Error("Invalid Compact IP/PORT, It should contain 6 bytes");
 
-  return buf[0] + "." + buf[1] + "." + buf[2] + "." + buf[3] + ":" + bops.readUInt16BE(buf, 4);
+  return buf[0] + "." + buf[1] + "." + buf[2] + "." + buf[3] + ":" + buf.readUInt16BE(4);
 };
 
 compact2string.multi = function  (buf) {
@@ -15,10 +13,8 @@ compact2string.multi = function  (buf) {
 
   var output = [];
   for (var i = 0; i <= buf.length - 1; i = i + 6) {
-    output.push(compact2string(bops.subarray(buf, i, i + 6)));
+    output.push(compact2string(buf.slice(i, i + 6)));
   }
 
   return output;
-
 };
-

--- a/package.json
+++ b/package.json
@@ -29,7 +29,5 @@
     "istanbul": "~0.1.44",
     "coveralls": "~2.3.0"
   },
-  "dependencies": {
-    "bops": "~0.1.0"
-  }
+  "dependencies": {}
 }

--- a/test.js
+++ b/test.js
@@ -1,8 +1,6 @@
 
 var assert = require('assert');
 var compact2string = require('./');
-var Buffer = require("buffer").Buffer;
-var bops = require('bops');
 
 describe('compact2string', function() {
 
@@ -24,10 +22,6 @@ describe('compact2string', function() {
     assert.throws(function() {
       compact2string.multi(new Buffer("0A0A0A05050505", "hex"));
     }, /multiple of/);
-  });
-
-  it('should return expected (when using bops in browser)', function() {
-    assert.equal('10.10.10.5:65408', compact2string(bops.from("0A0A0A05FF80", "hex")));
   });
 
 });


### PR DESCRIPTION
Browserify now uses native-buffer-browserify
(https://github.com/feross/native-buffer-browserify), a browser Buffer
implementation that is backed by Uint8Array so it’s just as fast
but also supports the node buffer API that we’re familiar with.
Best of both worlds!
