### PR TITLE
IPv6 support, split tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,38 @@
 module.exports = compact2string = function (buf) {
-
-  if(buf.length !== 6)
-    throw new Error("Invalid Compact IP/PORT, It should contain 6 bytes");
-
-  return buf[0] + "." + buf[1] + "." + buf[2] + "." + buf[3] + ":" + buf.readUInt16BE(4);
+  switch(buf.length) {
+  case 6:
+    return buf[0] + "." + buf[1] + "." + buf[2] + "." + buf[3] + ":" + buf.readUInt16BE(4);
+    break;
+  case 18:
+    var hexGroups = [];
+    for(var i = 0; i < 8; i++) {
+      hexGroups.push(buf.readUInt16BE(i * 2).toString(16));
+    }
+    return "[" + hexGroups.join(":") + "]:" + buf.readUInt16BE(16);
+  default:
+    throw new Error("Invalid Compact IP/PORT, It should contain 6 or 18 bytes");
+  }
 };
 
-compact2string.multi = function  (buf) {
-
+compact2string.multi = function (buf) {
   if(buf.length % 6 !== 0)
     throw new Error("buf length isn't multiple of compact IP/PORTs (6 bytes)");
 
   var output = [];
   for (var i = 0; i <= buf.length - 1; i = i + 6) {
     output.push(compact2string(buf.slice(i, i + 6)));
+  }
+
+  return output;
+};
+
+compact2string.multi6 = function (buf) {
+  if(buf.length % 18 !== 0)
+    throw new Error("buf length isn't multiple of compact IP6/PORTs (18 bytes)");
+
+  var output = [];
+  for (var i = 0; i <= buf.length - 1; i = i + 18) {
+    output.push(compact2string(buf.slice(i, i + 18)));
   }
 
   return output;

--- a/test.js
+++ b/test.js
@@ -1,19 +1,23 @@
-
 var assert = require('assert');
 var compact2string = require('./');
 
 describe('compact2string', function() {
 
-  it('should return expected', function() {
+  it('should return expected IPv4 address', function() {
     assert.equal('10.10.10.5:65408', compact2string(new Buffer("0A0A0A05FF80", "hex")));
   });
-
-  it('should throw an error if the buffer length isn\'t 6', function() {
-    assert.throws(function() {
-      compact2string(new Buffer("0A0A0A05", "hex"));
-    }, /should contain 6 bytes/);
+  it('should return expected IPv6 address', function() {
+    assert.equal('[2a03:2880:2110:9f07:face:b00c:0:1]:80', compact2string(new Buffer("2a03288021109f07faceb00c000000010050", "hex")));
   });
 
+  it('should throw an error if the buffer length isn\'t 6 or 18', function() {
+    assert.throws(function() {
+      compact2string(new Buffer("0A0A0A05", "hex"));
+    }, /should contain 6 or 18 bytes/);
+  });
+});
+
+describe('compact2string.multi', function() {
   it('should return expected multi', function() {
     assert.deepEqual([ '10.10.10.5:128', '100.56.58.99:28525' ], compact2string.multi(new Buffer("0A0A0A05008064383a636f6d", "hex")));
   });
@@ -21,6 +25,19 @@ describe('compact2string', function() {
   it('should throw an error if the buffer isn\'t a multiple of 6', function() {
     assert.throws(function() {
       compact2string.multi(new Buffer("0A0A0A05050505", "hex"));
+    }, /multiple of/);
+  });
+
+});
+
+describe('compact2string.multi6', function() {
+  it('should return expected multi6', function() {
+    assert.deepEqual([ '[2a03:2880:2110:9f07:face:b00c:0:1]:80', '[2a00:1450:4008:801:0:0:0:1010]:443' ], compact2string.multi6(new Buffer("2a03288021109f07faceb00c0000000100502a00145040080801000000000000101001bb", "hex")));
+  });
+
+  it('should throw an error if the buffer isn\'t a multiple of 18', function() {
+    assert.throws(function() {
+      compact2string.multi6(new Buffer("0A0A0A050505050A0A0A050505050A0A0A05050505", "hex"));
     }, /multiple of/);
   });
 


### PR DESCRIPTION
Considering that this module is made for P2P, IPv6 would be really nice. I intend to submit another PR to dependent module [bittorrent-tracker](https://www.npmjs.org/package/bittorrent-tracker).

Further compaction of IPv6 addresses (removing zeroes) may get more pretty results but that seems out of scope for this module. How about depending on something like the [ipv6](https://www.npmjs.org/package/ipv6) module?
